### PR TITLE
Change name of main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We want to make contributing to this project as easy and transparent as possible
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.


### PR DESCRIPTION
The name of the main branch is being renamed to `main`, so this PR updates `CONTRIBUTING.md` language accordingly